### PR TITLE
src/liberio.c: munmap ALL buffers on channel free

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([Liberio DMA Streaming], [0.3], [moritz.fischer@ettus.com])
+AC_INIT([Liberio DMA Streaming], [3.0.6], [moritz.fischer@ettus.com])
 AM_INIT_AUTOMAKE([foreign dist-xz])
 
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -2,4 +2,4 @@ lib_LTLIBRARIES = liberio.la
 
 liberio_la_SOURCES = log.c liberio.c liberio-util.c liberio-userptr.c liberio-mmap.c
 liberio_la_CPPFLAGS = -I$(top_srcdir)/include -D_GNU_SOURCE
-liberio_la_LDFLAGS = -version-info 3:5:0 -ludev
+liberio_la_LDFLAGS = -version-info 3:6:0 -ludev

--- a/src/liberio.c
+++ b/src/liberio.c
@@ -146,7 +146,7 @@ void liberio_ctx_register_logger(struct liberio_ctx *ctx, void (*cb)(int, const 
 
 static void __liberio_chan_free(const struct ref *ref)
 {
-	size_t i;
+	ssize_t i;
 	int err;
 	struct liberio_chan *chan = container_of(ref, struct liberio_chan,
 						refcnt);
@@ -156,7 +156,7 @@ static void __liberio_chan_free(const struct ref *ref)
 	if (!chan->bufs)
 		goto out;
 
-	for (i = chan->nbufs - 1; i > 0; i--)
+	for (i = chan->nbufs - 1; i >= 0; i--)
 		chan->ops->release(chan->bufs + i);
 
 	if (chan->dev)


### PR DESCRIPTION
A bug in the loop freeing resources caused the 0th buffer to remain
mapped to the user process. This fixes that issue.

Signed-off-by: Alex Williams <alex.williams@ni.com>